### PR TITLE
chore(main): Adjust example to also connect to Camunda Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ You can find the tutorial in the [Zeebe documentation](https://docs.camunda.io/d
 * [User Forum](https://forum.zeebe.io)
 * [Contribution Guidelines](/CONTRIBUTING.md)
 
-The code exists in two version:
-* `ApplicationCamundaCloud`- Client connecting to cluster in Camunda Cloud
-* `ApplicationDocker` - Client connecting to a cluster running in a Docker container
-
 ## Camunda Cloud Deployment
 
 Build the JAR file with Maven

--- a/README.md
+++ b/README.md
@@ -2,16 +2,48 @@
 
 This repository contains the source code of the Zeebe Get-Started Java client tutorial.
 
-You can find the tutorial in the [Zeebe documentation](http://docs.zeebe.io/clients/java-client/get-started).
+You can find the tutorial in the [Zeebe documentation](https://docs.camunda.io/docs/product-manuals/clients/java-client/get-started).
 
 * [Web Site](https://zeebe.io)
-* [Documentation](https://docs.zeebe.io)
+* [Documentation](https://docs.camunda.io)
 * [Issue Tracker](https://github.com/zeebe-io/zeebe/issues)
 * [Slack Channel](https://zeebe-slackin.herokuapp.com/)
 * [User Forum](https://forum.zeebe.io)
 * [Contribution Guidelines](/CONTRIBUTING.md)
 
-## Run with Maven
+The code exists in two version:
+* `ApplicationCamundaCloud`- Client connecting to cluster in Camunda Cloud
+* `ApplicationDocker` - Client connecting to a cluster running in a Docker container
+
+## Camunda Cloud Deployment
+
+Build the JAR file with Maven
+
+```
+mvn clean package
+```
+
+Export the connection settings as environment variables:
+
+```
+export ZEEBE_ADDRESS='[Zeebe API]'
+export ZEEBE_CLIENT_ID='[Client ID]'
+export ZEEBE_CLIENT_SECRET='[Client Secret]'
+export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
+```
+
+**Hint:** When you create client credentials in Camunda Cloud you have the option to download a file with above lines filled out for you.
+
+And execute it with Java
+
+```
+java -jar target/zeebe-get-started-java-client-0.1.0-jar-with-dependencies.jar
+```
+
+
+## Docker Deployment
+
+### Run with Maven
 
 Build the JAR file with Maven
 

--- a/src/main/java/io/zeebe/Application.java
+++ b/src/main/java/io/zeebe/Application.java
@@ -17,9 +17,9 @@ import java.util.Scanner;
  *
  * <ul>
  *   <li>ZEEBE_ADDRESS
- *   <li>ZEEBE_CLIENT_ID
- *   <li>ZEEBE_CLIENT_SECRET
- *   <li>ZEEBE_AUTHORIZATION_SERVER_URL
+ *   <li>ZEEBE_CLIENT_ID (implicitly required by {@code ZeebeClient} if authorization is enabled)
+ *   <li>ZEEBE_CLIENT_SECRET (implicitly required by {@code ZeebeClient} if authorization is enabled)
+ *   <li>ZEEBE_AUTHORIZATION_SERVER_URL (implicitly required by {@code ZeebeClient} if authorization is enabled)
  * </ul>
  *
  * <p><strong>Hint:</strong> When you create client credentials in Camunda Cloud you have the option

--- a/src/main/java/io/zeebe/Application.java
+++ b/src/main/java/io/zeebe/Application.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Scanner;
 
 /**
- * Sample application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
+ * Example application that connects to a cluster on Camunda Cloud, or a locally deployed cluster.
  *
  * <p>When connecting to a cluster in Camunda Cloud, this application assumes that the following
  * environment variables are set:


### PR DESCRIPTION
This PR adjusts the examples to align it better with Camunda Cloud and the docmentation for Camunda Cloud.

This getting started guide is referenced from the consolidated Camunda Cloud documentation where the cloud deployment scenario is the default.

Changes:
* Add section for Camunda Cloud to `README.md`
* Change example to connect to either a cluster in the cloud or to a local deployment
* Add JavaDoc to example to explain which environment variables need to be set for a connection to a cluster in Camunda Cloud
* Replace deprecated methods with their new counterparts

Related issue: https://github.com/camunda-cloud/camunda-cloud-documentation/issues/88